### PR TITLE
Fix sourcemaps when chaining loaders

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -42,9 +42,9 @@ module.exports = function(source, sm) {
   var res = ngAnnotate(source, getOptions.call(this, sourceMapEnabled, filename));
 
   if (sourceMapEnabled && sm) {
-    var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(sm));
+    var generator = SourceMapGenerator.fromSourceMap(new SourceMapConsumer(res.map));
     if (res.map) {
-      generator.applySourceMap(new SourceMapConsumer(res.map), filename);
+      generator.applySourceMap(new SourceMapConsumer(sm), filename);
       mergeMap = generator.toString();
     } else {
       mergeMap = sm;


### PR DESCRIPTION
The sourcemaps are passed the wrong way round which breaks them when using previous loaders. For example:
### Sample es6
```
import angular from 'angular';
var app = angular.module('myApp', []);

function testFactory($location) {
	'ngInject';	
}

app.factory('test', testFactory);

app.run(function($http) {
	throw new Error('test');
});
```

### Sample webpack config
```
module.exports = {
	entry: "./index",
	    output: {
	        path: __dirname + "/dist",
	        filename: "bundle.js"
	    },
   	module: {
	  loaders: [
	    {
	      test: /\.js?$/,
	      exclude: /(node_modules|bower_components)/,
	      loaders: ['ng-annotate', 'babel?optional[]=es7.decorators&optional[]=runtime']
	    }
	  ]
	},
	devtool: 'source-map'
};
```

If you run that in your browser you get this:
![screen shot 2015-07-02 at 00 18 08](https://cloud.githubusercontent.com/assets/6425649/8466931/e6c16172-204f-11e5-8cfd-ac7b59d844a1.png)
