### PR TITLE
Update babel example to take peer dependency to babel into account.

### DIFF
--- a/examples/babel/webpack.config.js
+++ b/examples/babel/webpack.config.js
@@ -1,5 +1,5 @@
-// Note: this example requires babel-loader
-// npm install babel-loader
+// Note: this example babel and equires babel-loader
+// npm install babel babel-loader
 
 var path = require('path');
 


### PR DESCRIPTION
Since npm 3 peer dependencies will not be installed automatically
(which was the default in npm 2.x). For this reason, running
  `npm install babel-loader`
in examples/babel will throw an error when running with npm 3.
This change simply updates the comment in webpack config to reflect
the need to install peer dependencies manually in npm 3.