### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ module: {
 	{test: /src.*\.js$/, loaders: ['ng-annotate?add=false&map=false']}
 ```
 
-[More about `ng-annotate` parameters](https://github.com/olov/ng-annotate#library-api)
+[More about `ng-annotate` parameters](https://github.com/olov/ng-annotate/blob/master/OPTIONS.md)
 
 #### Using ng-annotate plugins: 
 


### PR DESCRIPTION
Due to https://github.com/olov/ng-annotate/commit/23b53fa4ec766e367299b6a44556ad1f7372426e, the ng-annotate parameters are in a separate file.