### PR TITLE
Don't ignore errors from ng-annotate

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -75,7 +75,9 @@ module.exports = function(source, inputSourceMap) {
 
   var annotateResult = ngAnnotate(source, getOptions.call(this, sourceMapEnabled, filename));
 
-  if (annotateResult.src !== source) {
+  if (annotateResult.errors) {
+    this.callback(annotateResult.errors);
+  } else if (annotateResult.src !== source) {
     var outputSourceMap = mergeSourceMaps.call(this, inputSourceMap, annotateResult.map);
     this.callback(null, annotateResult.src || source, outputSourceMap);
   } else {


### PR DESCRIPTION
If `ngAnnotate()` fails, it returns an object like this (please ignore
this particular error - just an example):

```js
{ errors:
   [ 'error: couldn\'t process source due to parse error',
     '\'import\' and \'export\' may appear only with \'sourceType: module\' (1:0)' ] }
```

When this happens, the loader returns the original file. Instead, it
should report an error and fail.