### PR TITLE
Add an option to use a fork of ng-annotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ module: {
 }
 ```
 
+#### Using a fork of ng-annotate:
+
+```js
+{
+  test: /src.*\.js$/,
+  use: [
+    {
+      loader: 'ng-annotate-loader',
+      options: {
+        ngAnnotate: 'my-ng-annotate-fork'
+      }
+    }
+  ]
+}
+```
+
 #### Works great with js compilers, `babel` for example:
 
 ```js

--- a/loader.js
+++ b/loader.js
@@ -1,4 +1,3 @@
-var ngAnnotate = require('ng-annotate');
 var utils = require('loader-utils');
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var SourceMapGenerator = require('source-map').SourceMapGenerator;
@@ -73,6 +72,7 @@ module.exports = function(source, inputSourceMap) {
   var filename = normalizePath(this.resourcePath);
   this.cacheable && this.cacheable();
 
+  var ngAnnotate = require((utils.getOptions(this) || {}).ngAnnotate || 'ng-annotate');
   var annotateResult = ngAnnotate(source, getOptions.call(this, sourceMapEnabled, filename));
 
   if (annotateResult.errors) {


### PR DESCRIPTION
ng-annotate is no longer maintained[1], and hence fails when applied to
source code containing modern JavaScript constructs, like import and
export. In particular, this prevents usage with Webpack's ES6 modules
support (issue #17).

[1] https://github.com/olov/ng-annotate/issues/245

To work around it, allow the user to specify a fork of ng-annotate,
which adds support for new JS syntax.