### PR TITLE
Fix sourcemaps issues (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/huston007/ng-annotate-loader",
   "dependencies": {
+    "clone": "^2.1.1",
     "loader-utils": "1.1.0",
     "ng-annotate": "1.2.1",
     "normalize-path": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-annotate-loader",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Webpack loader that runs ng-annotate on your bundles",
   "main": "loader.js",
   "scripts": {


### PR DESCRIPTION
 Options objects passed by reference to loader, and first write to map property, share this value in next invocations. It cause incorrect filename in sourcemaps in subsequent calls (because map === undefined check is not passed).

Look at documentation for [loaderUtils.getOptions](https://github.com/webpack/loader-utils#getoptions):

> The returned options object is read-only. It may be re-used across multiple invocations. If you pass it on to another library, make sure to make a deep copy of it

So, this MR about it. Otherwise sourcemaps of annotated files are skipped in final bundle.
