### PR TITLE
feat: ng-annotate deprecated

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -21,7 +21,7 @@ function getOptions(sourceMapEnabled, filename) {
   }
 
   if (options.ngAnnotate === undefined) {
-    options.ngAnnotate = 'ng-annotate';
+    options.ngAnnotate = 'ng-annotate-patched';
   }
 
   if (sourceMapEnabled && options.map === undefined) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "clone": "^2.1.1",
     "loader-utils": "1.1.0",
-    "ng-annotate": "1.2.1",
+    "ng-annotate-patched": "^1.13.0",
     "normalize-path": "2.0.1",
     "source-map": "0.5.6"
   },


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x ] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x ] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x ] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [ x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [ ] If applicable, I’ve added docs and tests

### Description of changes

TODO
 ,add ng-annotate-patched support new syntax es6.
